### PR TITLE
Feature harvester plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,7 +78,7 @@ NGINX_PORT=80
 NGINX_SSLPORT=443
 
 # Extensions
-CKAN__PLUGINS="envvars image_view text_view recline_view datastore datapusher"
+CKAN__PLUGINS="envvars image_view text_view recline_view datastore datapusher harvest ckan_harvester dcat_json_harvester dcat_rdf_harvester"
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -17,8 +17,8 @@ FROM ckan/ckan-dev:2.10.1
 #    pip3 install -U requests[security]
 
 ### Harvester ###
-#RUN pip3 install -e 'git+https://github.com/ckan/ckanext-harvest.git@master#egg=ckanext-harvest' && \
-#    pip3 install -r ${APP_DIR}/src/ckanext-harvest/pip-requirements.txt
+RUN pip3 install -e 'git+https://github.com/ckan/ckanext-harvest.git@v1.5.6#egg=ckanext-harvest' && \
+   pip3 install -r ${APP_DIR}/src/ckanext-harvest/pip-requirements.txt
 # will also require gather_consumer and fetch_consumer processes running (please see https://github.com/ckan/ckanext-harvest)
 
 ### Scheming ###
@@ -28,8 +28,8 @@ FROM ckan/ckan-dev:2.10.1
 #RUN  pip3 install -e git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages
 
 ### DCAT ###
-#RUN  pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v0.0.6#egg=ckanext-dcat && \
-#     pip3 install -r https://raw.githubusercontent.com/ckan/ckanext-dcat/v0.0.6/requirements.txt
+RUN  pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v1.5.1#egg=ckanext-dcat && \
+    pip3 install -r https://raw.githubusercontent.com/ckan/ckanext-dcat/v1.5.1/requirements.txt
 
 # Clone the extension(s) your are writing for your own project in the `src` folder
 # to get them mounted in this image at runtime

--- a/ckan/docker-entrypoint.d/03_setup_harvest.sh
+++ b/ckan/docker-entrypoint.d/03_setup_harvest.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Cloning dataloader repo and install requirements"
+git clone https://github.com/national-data-platform/ckan-data-loader;
+cd ckan-data-loader;
+git checkout feature-harvester;
+pip install -r requirements.txt
+echo "Run harvest setup in the background"
+source ./setup_harvester.sh &
+
+


### PR DESCRIPTION
- ckanext harvester (v1.5.6) and dcat (v1.5.1) plugins are enabled by default
- sets up the harvester sources at startup. See https://github.com/national-data-platform/ckan-data-loader/pull/3. Similar to pgml startup script.